### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmctspublic.azurecr.io/base/java:21-distroless
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 ENV JAVA_OPTS ""
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "java"
 def product = "plum"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/charts/plum-batch/Chart.yaml
+++ b/charts/plum-batch/Chart.yaml
@@ -1,6 +1,6 @@
 name: plum-batch
 home: https://github.com/hmcts/cnp-plum-batch
-version: 0.0.7
+version: 0.0.8
 description: HMCTS Plum batch (test application)
 apiVersion: v2
 dependencies:

--- a/charts/plum-batch/Chart.yaml
+++ b/charts/plum-batch/Chart.yaml
@@ -5,5 +5,5 @@ description: HMCTS Plum batch (test application)
 apiVersion: v2
 dependencies:
   - name: job
-    version: 2.1.2
+    version: 2.2.0
     repository: 'https://hmctsprod.azurecr.io/helm/v1/repo/'

--- a/charts/plum-batch/Chart.yaml
+++ b/charts/plum-batch/Chart.yaml
@@ -6,4 +6,4 @@ apiVersion: v2
 dependencies:
   - name: job
     version: 2.1.2
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'https://hmctsprod.azurecr.io/helm/v1/repo/'

--- a/charts/plum-batch/values.yaml
+++ b/charts/plum-batch/values.yaml
@@ -1,5 +1,5 @@
 job:
-  image: hmctspublic.azurecr.io/plum/batch:latest
+  image: hmctsprod.azurecr.io/plum/batch:latest
   schedule: "*/1 * * * *"
 global:
   jobKind: CronJob 


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
